### PR TITLE
Added ZetaChain Athens 3 Testnet

### DIFF
--- a/data/chain-store/athens_7001-1.json
+++ b/data/chain-store/athens_7001-1.json
@@ -1,6 +1,6 @@
 {
-  "rpc": "https://rpc.ankr.com/zetachain_tendermint_athens_testnet",
-  "rest": "https://rpc.ankr.com/http/zetachain_athens_testnet",
+  "rpc": "https://zetachain-athens.blockpi.network/rpc/v1/public",
+  "rest": "https://zetachain-athens.blockpi.network/lcd/v1/public",
   "chainId": "athens_7001-1",
   "chainName": "ZetaChain Athens 3 Testnet",
   "image": "https://assets.leapwallet.io/athens_7001-1.png",
@@ -12,6 +12,7 @@
     "bech32PrefixConsAddr": "zetavalcons",
     "bech32PrefixConsPub": "zetavalconspub"
   },
+  "chainRegistryPath": "",
   "bip44": {
     "coinType": 60
   },
@@ -28,12 +29,14 @@
   "stakeCurrency": {
     "coinDenom": "tZETA",
     "coinDecimals": 18,
+    "coinGeckoId": "",
     "coinMinimalDenom": "azeta"
   },
   "currencies": [
     {
       "coinDenom": "tZETA",
       "coinDecimals": 18,
+      "coinGeckoId": "",
       "coinMinimalDenom": "azeta"
     }
   ],
@@ -42,6 +45,7 @@
       "coinDenom": "tZETA",
       "coinDecimals": 18,
       "coinMinimalDenom": "azeta",
+      "coinGeckoId": "",
       "gasPriceStep": {
         "low": 0.01,
         "average": 0.025,

--- a/data/chain-store/athens_7001-1.json
+++ b/data/chain-store/athens_7001-1.json
@@ -1,0 +1,53 @@
+{
+  "rpc": "https://rpc.ankr.com/zetachain_tendermint_athens_testnet",
+  "rest": "https://rpc.ankr.com/http/zetachain_athens_testnet",
+  "chainId": "athens_7001-1",
+  "chainName": "ZetaChain Athens 3 Testnet",
+  "image": "https://assets.leapwallet.io/athens_7001-1.png",
+  "bech32Config": {
+    "bech32PrefixAccAddr": "zeta",
+    "bech32PrefixAccPub": "zetapub",
+    "bech32PrefixValAddr": "zetavaloper",
+    "bech32PrefixValPub": "zetavaloperpub",
+    "bech32PrefixConsAddr": "zetavalcons",
+    "bech32PrefixConsPub": "zetavalconspub"
+  },
+  "bip44": {
+    "coinType": 60
+  },
+  "theme": {
+    "primaryColor": "#726FDC",
+    "gradient": "linear-gradient(180deg, rgba(105, 102, 255, 0.32) 0%, rgba(105, 102, 255, 0) 100%)"
+  },
+  "txExplorer": {
+    "mainnet": {
+      "name": "ZetaScan",
+      "txUrl": "https://athens3.explorer.zetachain.com/cc/tx"
+    }
+  },
+  "stakeCurrency": {
+    "coinDenom": "tZETA",
+    "coinDecimals": 18,
+    "coinMinimalDenom": "azeta"
+  },
+  "currencies": [
+    {
+      "coinDenom": "tZETA",
+      "coinDecimals": 18,
+      "coinMinimalDenom": "azeta"
+    }
+  ],
+  "feeCurrencies": [
+    {
+      "coinDenom": "tZETA",
+      "coinDecimals": 18,
+      "coinMinimalDenom": "azeta",
+      "gasPriceStep": {
+        "low": 0.01,
+        "average": 0.025,
+        "high": 0.04
+      }
+    }
+  ],
+  "features": []
+}


### PR DESCRIPTION
Hey! I'm proposing to add the ZetaChain Testnet.

It seems to be querying balances and gov proposals fine, but when I try to send tokens it's complaining about `coinDecimals`.

```
index.js:4994 TypeError: Cannot read properties of undefined (reading 'coinDecimals')
index.js:4997     GET https://assets.leapwallet.io/ibc-support-db/chains/zeta.json 403
```

<img width="399" alt="Screenshot 2023-07-13 at 18 21 21" src="https://github.com/leapwallet/developers/assets/332151/a2c3eac7-0d11-4f55-8bd1-c4ea15f14ab1">

<img width="399" alt="Screenshot 2023-07-13 at 18 21 24" src="https://github.com/leapwallet/developers/assets/332151/3cc7fe7b-b842-4822-b733-d725a7e51e6b">
